### PR TITLE
Updated and Edited the procedure for creating commits

### DIFF
--- a/developing_features/git_flow.md
+++ b/developing_features/git_flow.md
@@ -1,66 +1,44 @@
-# [Developing Features](../developing_features.md) / Git Flow
+# [Developing Features](../developing_features.md) / Committing Work
 
 #### Goals
 
 These processes should make it as easy as possible:
 
  1. for multiple developers to collaborate on a project
- 2. to deploy (and to roll back deploys)
- 3. to get insights from Git about when and why a change was made to the codebase
+ 2. to deploy reliably and frequently
+ 3. to review each other's code
+ 4. to document our intention with commit messages
 
 
 #### Tools Used
 
  - [Git](https://git-scm.com)
- - [GitHub](https://github.com)
- - `ep who`
- - `ep pair` / `ep unpair`
- - `ep respawn`
- - `ep merge`
+ - [GitHub](https://github.com/cph)
+ - `ep pair` (`ep unpair`, `ep who`)
+
 
 #### Procedures
 
-###### Branching
+ - We work on topic branches so that we may [create pull requests](pull_requests.md) for every change.
+   > - Never commit directly to `master`*
+   > - Pull `master`* before creating a branch
+   > - Rebase topic branches off of `master`* when `master`* changes
+   >
+   > <br> &#42; When a project has a beta environment, we've also had a branch off of <code>master</code> named <code>beta</code>. In this case, hotfixes are always based off <code>master</code> and new features are based off of <code>beta</code>.
+ - We make our commits discrete, atomic, and succinct in order to better communicate their intention.
+   > - Break separate logical changes into separate commits
+   > - Don't commit partial work; no commit should knowingly leave the project in a broken state
+   > - Minimize commit noise (changes that aren't relevant to the commit)
+   >
+   > <br> <h5>Rewriting Commits</h5> For a variety of reasons, we may not make discrete, atomic, and succinct commits <em>while working on a branch</em> — we may commit partial work, have a false start, or notice an oversight in a previous commit. We may then use tools like <code>git commit --amend</code>, <code>git rebase</code> and <code>git cherry-pick</code> to rewrite our branch's commits before requesting a review. Our goal is to make code review easier and git history more useful.
+ - When pairing, we make commits jointly using `ep pair`
+ - We [label commits](https://github.com/cph/style-guides#commits) to help Houston create release notes and resolve alerts automatically.
+   > - Use `[feature]`, `[improvement]` and `[fix]` on changes that should be mentioned in release notes
+   > - Use `[skip]` or `[refactor]` on changes that should not be mentioned in release notes
+   > - Other labels like `[squash]` and `[wip]` may be useful for work-in-progress but should never be merged to `master`. (see <strong>Rewriting Commits</strong> above)
+ - We [create a Pull Request](pull_requests.md) as soon as we are ready to [deploy our work to Staging](../deploying_changes/staging.md) for [Testing](../deploying_changes/testing.md), to request a [review](../deploying_changes/code_review.md), or to share our work-in-progress with other developers.
 
- - Always work on topic branches. If you are working on a feature in the regular roadmap (and if the project has a `beta` branch), create your topic branch off of `beta`. If you are working on an alert (or if the project doens't have a `beta` branch), you should branch off of `master`.
- - Before branching, make sure your local copy of either the `master` or `beta` branch is up-to-date with the `origin` by fetching and using `git pull` to fast-forward. Sometimes, the `beta` branch will not be able to be fast-forwarded. In this case, you may wish to use `ep respawn beta` in order to pull a fresh copy of the `beta` branch down from the remote server.
- - Branch names are typically lower-case, with words separated by dashes. Names should balance being succinct, yet descriptive.
 
-###### Committing
+ #### Related Topics
 
- - Commits should be as small as possible while maintaining the code in a workable state. We try not to commit code when the project is in a broken state.
- - When committing, we strive to minimize "commit noise", i.e., changes that don't affect the code or state of the project, especially whitespace changes.
- - You may wish to double-check as whom you're committing using `ep who`. If you are pairing with someone, use `ep pair` to change your git identity to the combined identities of those pairing. E.g., `ep pair matt bob chase ben` would combine those four git identities into one. Use `ep unpair` to go back to committing as only yourself.
- - Be sure to follow our [Style Guide](https://github.com/cph/style-guides) for commits.
-
-
-###### Pushing
-
- - Push your branch to GitHub regularly.
- - _**Always**_ double-check that you will not be overwriting other work before forcing a push!
- - When you push your changes, if a pull request does not yet exist for the branch, [create a Pull Request](pull_requests.md) for your branch. (Note: Houston will prune remote branches without an open pull request on a weekly basis.)
-
-###### Merging
-
- - Ordinarily, combining related topic branches is accomplished via rebasing. Incorporating topic branches back into their base branch (`master` or `beta`) is accomplished via merging.
- - To merge two branches, switch to the branch _into which_ you wish to merge your topic branch. Then, use `ep merge topic-branch-name` to merge the two branches.
- - `ep merge` will automatically attempt to rebase your topic branch on the base branch before merging the two.
- - We usually leave the default merge message (e.g., "Merged branch 'topic-branch-name'") when merging back into the main branch.
-
-###### Rebasing
-
- - When combining related topic branches or incorporating work added upstream (e.g., when branches are merged into either `master` or `beta` since you branched off), we ordinarily rebase.
- - We always do an interactive rebase; this allows us not only to edit and skip commits, but more fundamentally to check that the rebase will do what we're expecting it to do..
- - Occasionally we use rebasing to tweak past work. This is not ordinarily done (a new commit is usually best), but it can be used when fixing a small typo or error in a previous commit or when editing a migration.
- - After rebasing, when you go to push, you will almost certainly need the `-f` flag to force the push. _Always ensure you will not be overwriting other changes before forcing a push_ (See above)!
-
-###### Squashing Commits
-
- - After a feature has been fully developed, we will squash the commits before merging into the base branch. This is usually done for larger features which are logically distinct, but are made up of many small commits.
- - Use interactive rebasing to squash commits into the smallest number of commits (usually 1 or 2) that make sense for the feature.
- - Make sure that the commit message of the commit into which the others are squashed is well-written and will be useful for release notes. The other commit messages (which Git puts by default into the description section of the target commit) may be discarded.
-
-#### Related Topics
- 
- - [Git documentation](https://git-scm.com/doc)
- - [Creating a Pull Request](pull_requests.md)
+  - [Style Guide for Commits](https://github.com/cph/style-guides#commits)


### PR DESCRIPTION
[Preview](https://github.com/cph/desktop-procedures/blob/amend-git-flow/developing_features/git_flow.md)

The old procedure discussed `ep merge` which probably shouldn't be in this document for two reasons:

 1. We no longer use that tool
 2. It belongs more to the Deploying Changes "chapter" than the Developing Features one — this procedure is applicable to any developer; merging Pull Requests is applicable particularly to developers acting in the role of Project Maintainer.

I also edited the document down to a smaller word count in the effort to keep the repo succinct.

In editing, I chose to focus on the higher-level content that succinctly encodes our rules and conventions — content that's perennially of interest to any developer in EP — as opposed to content that you might learn once and have no need of re-referencing (like when you'll need to use `-f` to force-push or that you might want to `ep unpair` after pairing).